### PR TITLE
modif r.status_code in __call__

### DIFF
--- a/zebitex/zebitex.py
+++ b/zebitex/zebitex.py
@@ -68,7 +68,7 @@ class Zebitex():
         status = {'status_code': r.status_code}
         if r.status_code >= 500:
             raise ZebitexError(status)
-        if r.status_code is not 200 and r.status_code is not 204:
+        if r.status_code is not 200 and r.status_code is not 201:
             raise ZebitexError({**status, **r.json()['error']})
         return r.json()
 


### PR DESCRIPTION
Api return 201 status code after a POST instead of 204. All other commands tested with success regarding status code.